### PR TITLE
Update Common.xsd

### DIFF
--- a/CUFX/Schemas/Common.xsd
+++ b/CUFX/Schemas/Common.xsd
@@ -29,7 +29,7 @@
 				</xs:annotation>
 			</xs:element>
 
-			<xs:element name="currencyCode" type="isoCurrencyCodeType:ISOCurrencyCodeType" minOccurs ="1" maxOccurs="1" default ="USD">
+			<xs:element name="currencyCode" type="isoCurrencyCodeType:ISOCurrencyCodeType" minOccurs ="0" maxOccurs="1" default ="USD">
 				<xs:annotation>
 					<xs:documentation>
 						Currency code in ISO 4217 3 character format.


### PR DESCRIPTION
Currency code inconsistency identified by Celero.  Documentation and format clearly indicates this should be an optional field.