### PR TITLE
Update ProductOffering.xsd

### DIFF
--- a/CUFX/Schemas/Common.xsd
+++ b/CUFX/Schemas/Common.xsd
@@ -1113,5 +1113,19 @@
 		<xs:restriction base="xs:string">
 		</xs:restriction>
 	</xs:simpleType>
+	
+	<xs:simpleType name="AnnualPercentageRate">
+		<xs:annotation>
+			<xs:documentation>
+				Calculated annual percentage rate (APR). Is the interest rate for a whole year (annualized). 
+				Value is formatted as a percentile. A passed value of 4.5 is equivalent to 0.045 actual.
+				4.500 may be displayed as 4.500% or 4.5% depending on the user interface.
+				Decimals available: 999.999 
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:decimal">
+		</xs:restriction>
+	</xs:simpleType>
+	
 </xs:schema>
 

--- a/CUFX/Schemas/Meta.xsd
+++ b/CUFX/Schemas/Meta.xsd
@@ -95,7 +95,7 @@
 					</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="annualPercentageRate" type="xs:decimal" minOccurs="0" maxOccurs="1">
+			<xs:element name="annualPercentageRate" type="common:AnnualPercentageRate" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>
 						Calculated annual percentage rate (APR). Is the interest rate for a whole year (annualized).

--- a/CUFX/Schemas/ProductOffering.xsd
+++ b/CUFX/Schemas/ProductOffering.xsd
@@ -280,6 +280,13 @@
 					</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+			<xs:element name="aprRate" type="xs:decimal" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						The interest rate calculated as an annual percentage rate, as defined by the FI.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
 

--- a/CUFX/Schemas/ProductOffering.xsd
+++ b/CUFX/Schemas/ProductOffering.xsd
@@ -280,7 +280,7 @@
 					</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="aprRate" type="xs:decimal" minOccurs="0" maxOccurs="1">
+			<xs:element name="apr" type="common:AnnualPercentageRate" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>
 						The interest rate calculated as an annual percentage rate, as defined by the FI.


### PR DESCRIPTION
Since APR calculation may be unique to the FI, providing an optional field for pre-calculated APR allows this information to be easily available for a client application without needing to duplicate the FI's APR calculation and appropriate significant digits.