### PR TITLE
Update Account.xsd

### DIFF
--- a/CUFX/Schemas/Account.xsd
+++ b/CUFX/Schemas/Account.xsd
@@ -298,7 +298,7 @@
 							</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="meta" type="meta:Meta" minOccurs="0"	maxOccurs="1" nillable="true">
+					<xs:element name="meta" type="meta:Meta" minOccurs="0"	maxOccurs="1">
 						<xs:annotation>
 							<xs:documentation>
 								For each account type, optional meta information MAY be provided with these tags depending
@@ -348,7 +348,7 @@
 		<xs:complexContent>
 			<xs:extension base="common:ListBase">
 				<xs:sequence>
-					<xs:element name="totalToDate" type="TotalToDate" minOccurs="0" maxOccurs="unbounded" nillable="true" >
+					<xs:element name="totalToDate" type="TotalToDate" minOccurs="0" maxOccurs="unbounded" >
 						<xs:annotation>
 							<xs:documentation>
 								A list of aggregate totals of type TotalsToDate, i.e. YTD Dividend, MTD Interest.


### PR DESCRIPTION
Removing nillable='true'. When in combination of min occurs =0 ; then JAVA compilation may not link the object correctly.  Nillable true and min occurs 0 is effectively redundant. However, it may be possible that there are implementations of CUFX using Nil with these elements and is therefore a potential breaking change.