### PR TITLE
Update Configuration.xsd

### DIFF
--- a/CUFX/Schemas/Configuration.xsd
+++ b/CUFX/Schemas/Configuration.xsd
@@ -6,6 +6,7 @@
 	xmlns:app="http://cufxstandards.com/v4/App.xsd"
 	xmlns:common="http://cufxstandards.com/v4/Common.xsd"
 	xmlns:isoCurrencyCodeType="http://cufxstandards.com/v4/ISOCurrencyCodeType.xsd"
+	xmlns:financialInstitution="http://cufxstandards.com/v4/FinancialInstitution.xsd"   
 	xmlns:party="http://cufxstandards.com/v4/Party.xsd"
 	xmlns:networkNode="http://cufxstandards.com/v4/NetworkNode.xsd"
 	xmlns:user="http://cufxstandards.com/v4/User.xsd"
@@ -16,6 +17,7 @@
 	<xs:import namespace="http://cufxstandards.com/v4/App.xsd" schemaLocation="App.xsd" />
 	<xs:import namespace="http://cufxstandards.com/v4/Common.xsd" schemaLocation="Common.xsd" />
 	<xs:import namespace="http://cufxstandards.com/v4/ISOCurrencyCodeType.xsd" schemaLocation="ISOCurrencyCodeType.xsd" />
+	<xs:import namespace="http://cufxstandards.com/v4/FinancialInstitution.xsd" schemaLocation="FinancialInstitution.xsd" />
 	<xs:import namespace="http://cufxstandards.com/v4/Party.xsd" schemaLocation="Party.xsd" />
 	<xs:import namespace="http://cufxstandards.com/v4/NetworkNode.xsd" schemaLocation="NetworkNode.xsd" />
 	<xs:import namespace="http://cufxstandards.com/v4/User.xsd" schemaLocation="User.xsd" />
@@ -108,7 +110,7 @@
 					</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="fiIdList" type="FinancialInstitutionIdList" minOccurs ="0" maxOccurs ="1">
+			<xs:element name="fiIdList" type="financialInstitution:FinancialInstitutionIdList" minOccurs ="0" maxOccurs ="1">
 				<xs:annotation>
 					<xs:documentation>
 						The valid financial institution ID list for this instance.
@@ -118,7 +120,7 @@
 					</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="fiList" type="FinancialInstitutionList" minOccurs ="0" maxOccurs ="1">
+			<xs:element name="fiList" type="ConfigurationFinancialInstitutionList" minOccurs ="0" maxOccurs ="1">
 				<xs:annotation>
 					<xs:documentation>
 						The list of Financial institution within this configuration.
@@ -310,29 +312,6 @@
 		</xs:complexContent>
 	</xs:complexType>
 
-	<xs:complexType name="FinancialInstitutionIdList">
-		<xs:annotation>
-			<xs:documentation>
-				The valid financial institution list for this instance.
-				Identifies that these configuration parameters are related to these financial institutions.
-			</xs:documentation>
-		</xs:annotation>
-		<xs:complexContent>
-			<xs:extension base="common:ListBase">
-				<xs:sequence>
-					<xs:element name="fiId" type="common:FinancialInstitutionId" minOccurs ="0" maxOccurs ="unbounded">
-						<xs:annotation>
-							<xs:documentation>
-								A valid financial institution for this instance.
-								Identifies that these configuration parameters are related to this financial institution.
-							</xs:documentation>
-						</xs:annotation>
-					</xs:element>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-
 	<xs:complexType name="ConfigurationAppList">
 		<xs:complexContent>
 			<xs:extension base="common:ListBase">
@@ -516,11 +495,11 @@
 		</xs:complexContent>
 	</xs:complexType>
 
-	<xs:complexType name="FinancialInstitutionList">
+	<xs:complexType name="ConfigurationFinancialInstitutionList">
 		<xs:complexContent>
 			<xs:extension base="common:ListBase">
 				<xs:sequence>
-					<xs:element name="financialInstitution" type="ConfigurationFinancialInstitution" minOccurs ="0" maxOccurs ="unbounded">
+					<xs:element name="configurationFinancialInstitution" type="ConfigurationFinancialInstitution" minOccurs ="0" maxOccurs ="unbounded">
 						<xs:annotation>
 							<xs:documentation>
 								List of financial institution within this configuration.


### PR DESCRIPTION
correct use of FI ID List to use definition from financial institution.  corrected naming of FinancialInstitutionList to ConfigurationFinancialInstitutionList to resolve duplicate naming. The objects are different and unique.